### PR TITLE
Rewrite the toggle logic with bug fixed

### DIFF
--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -47,21 +47,23 @@ command! QToggle call <sid>QListToggle()
 command! LToggle call <sid>LListToggle()
 
 function! s:LListToggle()
-    let buffer_count_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+    let buffer_count_before = s:BufferCount()
     silent! lclose
-    let buffer_count_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
 
-    if buffer_count_before == buffer_count_after
+    if s:BufferCount() == buffer_count_before
         execute "silent! lopen " . g:lt_height
     endif
 endfunction
 
 function! s:QListToggle()
-    let buffer_count_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+    let buffer_count_before = s:BufferCount()
     silent! cclose
-    let buffer_count_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
 
-    if buffer_count_before == buffer_count_after
+    if s:BufferCount() == buffer_count_before
         execute "silent! botright copen " . g:lt_height
     endif
+endfunction
+
+function! s:BufferCount()
+    return len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
 endfunction

--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -18,6 +18,11 @@
 "
 " See ':help listtoggle' for more information.
 
+if exists('g:loaded_listtoggle')
+  finish
+endif
+let g:loaded_listtoggle = 1
+
 let g:lt_height = get( g:, 'lt_height', 10 )
 let g:lt_location_list_toggle_map =
       \ get( g:, 'lt_location_list_toggle_map', '<leader>l' )

--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -42,21 +42,21 @@ command! QToggle call <sid>QListToggle()
 command! LToggle call <sid>LListToggle()
 
 function! s:LListToggle()
-    let b_num_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+    let buffer_count_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
     silent! lclose
-    let b_num_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+    let buffer_count_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
 
-    if b_num_after == b_num_before
+    if buffer_count_before == buffer_count_after
         execute "silent! lopen " . g:lt_height
     endif
 endfunction
 
 function! s:QListToggle()
-    let b_num_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+    let buffer_count_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
     silent! cclose
-    let b_num_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+    let buffer_count_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
 
-    if b_num_after == b_num_before
+    if buffer_count_before == buffer_count_after
         execute "silent! botright copen " . g:lt_height
     endif
 endfunction

--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -18,11 +18,6 @@
 "
 " See ':help listtoggle' for more information.
 
-if exists('g:loaded_listtoggle')
-  finish
-endif
-let g:loaded_listtoggle = 1
-
 let g:lt_height = get( g:, 'lt_height', 10 )
 let g:lt_location_list_toggle_map =
       \ get( g:, 'lt_location_list_toggle_map', '<leader>l' )
@@ -46,39 +41,22 @@ execute "nnoremap " . s:unique . " <silent> " .
 command! QToggle call <sid>QListToggle()
 command! LToggle call <sid>LListToggle()
 
-
 function! s:LListToggle()
-  if exists("s:quickfix_buffer_number")
+    let b_num_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
     silent! lclose
-  else
-    execute "silent! lopen " . g:lt_height
-  endif
-endfunction
+    let b_num_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
 
+    if b_num_after == b_num_before
+        execute "silent! lopen " . g:lt_height
+    endif
+endfunction
 
 function! s:QListToggle()
-  if exists("s:quickfix_buffer_number")
+    let b_num_before = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
     silent! cclose
-  else
-    execute "silent! botright copen " . g:lt_height
-  endif
+    let b_num_after = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+
+    if b_num_after == b_num_before
+        execute "silent! botright copen " . g:lt_height
+    endif
 endfunction
-
-
-function s:CheckIsQuickfixWindowClosing()
-  if exists("s:quickfix_buffer_number") &&
-        \ expand("<abuf>") == s:quickfix_buffer_number
-    unlet! s:quickfix_buffer_number
-  endif
-endfunction
-
-
-function s:GetQuickFixBufferNumber()
-  let s:quickfix_buffer_number = bufnr('$')
-endfunction
-
-
-augroup ListToggle
-  autocmd BufWinEnter quickfix call s:GetQuickFixBufferNumber()
-  autocmd BufWinLeave * call s:CheckIsQuickfixWindowClosing()
-augroup END


### PR DESCRIPTION
There is a bug in previous version. I find the original toggle logic some complex, so I try to used a different way to implement it. The bug was fixed of course. :)

Bug details:
After the location buffer closed by hit <Enter> on the selected item on the buffer, the open/close key mapping will not work anymore. The same thing happens on quick-fix buffer. 
