### PR TITLE
Fix E116 error on fuctions calling

### DIFF
--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -43,8 +43,8 @@ execute "nnoremap " . s:unique . " <silent> " .
 execute "nnoremap " . s:unique . " <silent> " .
       \ g:lt_quickfix_list_toggle_map . " :QToggle<CR>"
 
-command! QToggle call <sid>QListToggle()
-command! LToggle call <sid>LListToggle()
+command!  QToggle call s:QListToggle()
+command!  LToggle call s:LListToggle()
 
 function! s:LListToggle()
     let buffer_count_before = s:BufferCount()


### PR DESCRIPTION
Using <sid> produces E116 errors like:
`E116: Invalid arguments for function 37_LListToggle`
use of s: instead will fix this.
