### PR TITLE
If focus on location list buffer, need to unfocus for toggle it again

### DIFF
--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -49,6 +49,7 @@ command! LToggle call <sid>LListToggle()
 function! s:LListToggle()
     let buffer_count_before = s:BufferCount()
     silent! lclose
+    silent! lclose
 
     if s:BufferCount() == buffer_count_before
         execute "silent! lopen " . g:lt_height

--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -48,6 +48,8 @@ command! LToggle call <sid>LListToggle()
 
 function! s:LListToggle()
     let buffer_count_before = s:BufferCount()
+    " Location list can't be closed if there's cursor in it, so we need 
+    " to call lclose twice to move cursor to the main pane
     silent! lclose
     silent! lclose
 


### PR DESCRIPTION
There's one problem in toggling of Location list. If the focus (cursor) is on that buffer, you can't toggle it without moving cursor to your main buffer. Executing of `lclose` once again will move focus and solve this.
