### PR TITLE
Map keys native way, with <SID> and <Plug> also

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ location-list. Install it with [Vundle][] or [Pathogen][] (I recommend Vundle).
 You can set the key mappings for toggling Vim's `locationlist` and `quickfix`
 windows in your vimrc file:
 
-    let g:lt_location_list_toggle_map = '<leader>l'
-    let g:lt_quickfix_list_toggle_map = '<leader>q'
+    nmap <Leader>q <Plug>QToggle
+    nmap <Leader>l <Plug>Ltoggle
 
 By default, they are set to `<leader>l` and `<leader>q`, respectively.
 

--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -24,27 +24,25 @@ endif
 let g:loaded_listtoggle = 1
 
 let g:lt_height = get( g:, 'lt_height', 10 )
-let g:lt_location_list_toggle_map =
-      \ get( g:, 'lt_location_list_toggle_map', '<leader>l' )
-let g:lt_quickfix_list_toggle_map =
-      \ get( g:, 'lt_quickfix_list_toggle_map', '<leader>q' )
 
-" If the user has explicitly set some mappings, then we don't use <unique> when
-" creating the mappings; the user obviously wants to use them
-if g:lt_location_list_toggle_map != '<leader>l' ||
-      \ g:lt_quickfix_list_toggle_map != '<leader>q'
-  let s:unique = ''
-else
-  let s:unique = '<unique>'
+if !hasmapto('<Plug>QToggle')
+  nmap <unique> <Leader>q <Plug>QToggle
 endif
 
-execute "nnoremap " . s:unique . " <silent> " .
-      \ g:lt_location_list_toggle_map . " :LToggle<CR>"
-execute "nnoremap " . s:unique . " <silent> " .
-      \ g:lt_quickfix_list_toggle_map . " :QToggle<CR>"
+if !hasmapto('<Plug>LToggle')
+  nmap <unique> <Leader>l <Plug>LToggle
+endif
 
-command!  QToggle call s:QListToggle()
-command!  LToggle call s:LListToggle()
+nnoremap <unique> <silent> <Plug>QToggle :call <SID>QListToggle()<CR>
+nnoremap <unique> <silent> <Plug>LToggle :call <SID>LListToggle()<CR>
+
+if !exists(":QToggle")
+  command -nargs=0  QToggle :call s:QListToggle()
+endif
+
+if !exists(":Ltoggle")
+  command -nargs=0  LToggle :call s:LListToggle()
+endif
 
 function! s:LListToggle()
     let buffer_count_before = s:BufferCount()


### PR DESCRIPTION
Hi! Just for self-education I've started to investigate what exactly was wrong with <SID> and why it's recommended to use it. As a result, I've made some minor changes according to vimdoc on writing plugins and made the plugin use a native way to map keys instead of setting variables.
Please, take a look.
