### PR TITLE
GH-6: don't map keys by default: leave it to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ location-list. Install it with [Vundle][] or [Pathogen][] (I recommend Vundle).
 You can set the key mappings for toggling Vim's `locationlist` and `quickfix`
 windows in your vimrc file:
 
-    let g:lt_location_list_toggle_map = '<leader>l'
-    let g:lt_quickfix_list_toggle_map = '<leader>q'
-
-By default, they are set to `<leader>l` and `<leader>q`, respectively.
+    nnoremap <silent> <leader>l :LToggle<CR>
+    nnoremap <silent> <leader>q :QToggle<CR>
 
 Here's how you can set the height (in number of lines) of the spawned window:
 

--- a/plugin/listtoggle.vim
+++ b/plugin/listtoggle.vim
@@ -24,24 +24,6 @@ endif
 let g:loaded_listtoggle = 1
 
 let g:lt_height = get( g:, 'lt_height', 10 )
-let g:lt_location_list_toggle_map =
-      \ get( g:, 'lt_location_list_toggle_map', '<leader>l' )
-let g:lt_quickfix_list_toggle_map =
-      \ get( g:, 'lt_quickfix_list_toggle_map', '<leader>q' )
-
-" If the user has explicitly set some mappings, then we don't use <unique> when
-" creating the mappings; the user obviously wants to use them
-if g:lt_location_list_toggle_map != '<leader>l' ||
-      \ g:lt_quickfix_list_toggle_map != '<leader>q'
-  let s:unique = ''
-else
-  let s:unique = '<unique>'
-endif
-
-execute "nnoremap " . s:unique . " <silent> " .
-      \ g:lt_location_list_toggle_map . " :LToggle<CR>"
-execute "nnoremap " . s:unique . " <silent> " .
-      \ g:lt_quickfix_list_toggle_map . " :QToggle<CR>"
 
 command!  QToggle call s:QListToggle()
 command!  LToggle call s:LListToggle()


### PR DESCRIPTION
This patch eliminates unnecessary mapping code, replacing indirection
(the `g:lt_*_list_toggle_map` variables) with Vim's native map syntax.
